### PR TITLE
Adds arbitrary date parsing

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -151,6 +151,78 @@ RETURN *;
 * `apoc.coll.containsSorted(coll, value)` optimized contains on a sorted list operation (Collections.binarySearch) (returns single row or not)
 
 
+=== Date/time Support
+
+==== Conversion between formatted dates and timestamps
+
+* `apoc.date.toSeconds('2015-03-25 03:15:59')` get Unix time equivalent of given date (in seconds)
+* `apoc.date.toSecondsFormatted('2015/03/25 03-15-59', 'yyyy/MM/dd HH/mm/ss')` same as previous, but accepts custom datetime format
+* `apoc.date.fromSeconds(12345)` get string representation of date corresponding to given Unix time (in seconds)
+* `apoc.date.fromSecondsFormatted(12345, 'yyyy/MM/dd HH/mm/ss')` the same as previous, but accepts custom datetime format
+
+==== Reading separate datetime fields:
+
+Splits date (optionally, using given custom format) into fields returning a map from field name to its value.
+Following fields are supported:
+
+[options="header"]
+|===============================================================================================================
+| Result field	| Represents
+| 'Years'		| year
+| 'Months' 		| month of year
+| 'Days' 		| day of month
+| 'Hours' 		| hour of day
+| 'Minutes' 	| minute of hour
+| 'Seconds'		| second of minute
+| 'ZoneId'		| https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html#timezone[time zone]
+|===============================================================================================================
+
+==== Examples
+
+....
+  apoc.date.listFields('2015-03-25 03:15:59') =>
+    {
+      'Months': 1,
+      'Days': 2,
+      'Hours': 3,
+      'Minutes': 4,
+      'Seconds': 5,
+      'Years': 2015
+    }
+....
+
+....
+apoc.date.listFieldsFormatted('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz') =>
+  {
+    'ZoneId': 'Europe/Bucharest',
+    'Months': 1,
+    'Days': 2,
+    'Hours': 3,
+    'Minutes': 4,
+    'Seconds': 5,
+    'Years': 2015
+  }
+....
+
+....
+apoc.date.listFieldsFormatted('2015/01/02_EET', 'yyyy/MM/dd_z') =>
+  {
+    'Years': 2015,
+    'ZoneId': 'Europe/Bucharest',
+    'Months': 1,
+    'Days': 2
+  }
+....
+
+
+==== Notes on formats:
+
+* the default format is `yyyy-MM-dd HH:mm:ss`
+* if the format pattern doesn't specify timezone, formatter considers dates to belong to the UTC timezone
+* if the timezone pattern is specified, the timezone is extracted from the date string, otherwise an error will be reported
+* the `to/fromSeconds` timestamp values are in POSIX (Unix time) system, i.e. timestamps represent the number of seconds elapsed since https://en.wikipedia.org/wiki/Unix_time[00:00:00 UTC, Thursday, 1 January 1970]
+* the full list of supported formats is described in https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html[SimpleDateFormat JavaDoc]
+
 == Plans
 
 * warmup procedures that load nodes / rels by skipping one page at a time (8kb/15bytes) (8kb/35bytes)

--- a/src/main/java/apoc/date/Date.java
+++ b/src/main/java/apoc/date/Date.java
@@ -1,0 +1,139 @@
+package apoc.date;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
+import java.time.temporal.TemporalQuery;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import apoc.result.LongResult;
+import apoc.result.MapResult;
+import apoc.result.StringResult;
+import org.neo4j.procedure.Name;
+import org.neo4j.procedure.Procedure;
+
+
+/**
+ * @author tkroman
+ * @since 9.04.2016
+ */
+public class Date {
+	private static final String DEFAULT_FORMAT = "yyyy-MM-dd HH:mm:ss";
+	private static final int MILLIS_IN_SECOND = 1000;
+	private static final String UTC_ZONE_ID = "UTC";
+	private static final List<TemporalQuery<Consumer<Map<String, Object>>>> DT_FIELDS_SELECTORS = Arrays.asList(
+			temporalQuery(ChronoField.YEAR),
+			temporalQuery(ChronoField.MONTH_OF_YEAR),
+			temporalQuery(ChronoField.DAY_OF_MONTH),
+			temporalQuery(ChronoField.HOUR_OF_DAY),
+			temporalQuery(ChronoField.MINUTE_OF_HOUR),
+			temporalQuery(ChronoField.SECOND_OF_MINUTE),
+			temporal -> map -> Optional.ofNullable(TemporalQueries.zone().queryFrom(temporal))
+					.ifPresent(zoneId -> map.put("ZoneId", zoneId.getId()))
+	);
+
+	@Procedure
+	public Stream<MapResult> listFields(final @Name("date") String date) {
+		return listFieldsFormatted(date, null);
+	}
+
+	@Procedure
+	public Stream<MapResult> listFieldsFormatted(final @Name("date") String date, final @Name("pattern") String pattern) {
+		if (date == null) {
+			return Stream.of(MapResult.empty());
+		}
+		DateTimeFormatter fmt = getDateTimeFormatter(pattern);
+		TemporalAccessor temporal = fmt.parse(date);
+		Map<String, Object> selectFields = new HashMap<>();
+
+		for (final TemporalQuery<Consumer<Map<String, Object>>> query : DT_FIELDS_SELECTORS) {
+			query.queryFrom(temporal).accept(selectFields);
+		}
+
+		return Stream.of(new MapResult(selectFields));
+	}
+
+	@Procedure
+	public Stream<StringResult> fromSeconds(final @Name("seconds") long unixtime) {
+		return fromSecondsFormatted(unixtime, null);
+	}
+
+	@Procedure
+	public Stream<StringResult> fromSecondsFormatted(final @Name("seconds") long unixtime, final @Name("pattern") String pattern) {
+		if (unixtime < 0) {
+			throw new IllegalArgumentException("The time argument should be >= 0, got: " + unixtime);
+		}
+		return Stream.of(new StringResult(getFormat(pattern).format(new java.util.Date(unixtime * MILLIS_IN_SECOND))));
+	}
+
+	@Procedure
+	public Stream<LongResult> toSeconds(final @Name("date") String dateField) {
+		return toSecondsFormatted(dateField, null);
+	}
+
+	@Procedure
+	public Stream<LongResult> toSecondsFormatted(final @Name("date") String dateField, final @Name("pattern") String pattern) {
+		if (dateField == null) {
+			return null;
+		}
+		DateFormat format = getFormat(pattern);
+		java.util.Date parse = parseOrThrow(dateField, format);
+		return Stream.of(new LongResult(parse.getTime() / 1000));
+	}
+
+	private static DateFormat getFormat(final String pattern) {
+		String actualPattern = getPattern(pattern);
+		SimpleDateFormat format = new SimpleDateFormat(actualPattern);
+		if (!(containsTimeZonePattern(actualPattern))) {
+			format.setTimeZone(TimeZone.getTimeZone(UTC_ZONE_ID));
+		}
+		return format;
+	}
+
+	private static DateTimeFormatter getDateTimeFormatter(final String pattern) {
+		String actualPattern = getPattern(pattern);
+		DateTimeFormatter fmt = DateTimeFormatter.ofPattern(actualPattern);
+		if (!containsTimeZonePattern(actualPattern)) {
+			return fmt.withZone(ZoneId.of(UTC_ZONE_ID));
+		} else {
+			return fmt;
+		}
+	}
+
+	private static java.util.Date parseOrThrow(final String date, final DateFormat format) {
+		final java.util.Date parsed;
+		try {
+			parsed = format.parse(date);
+		} catch (ParseException e) {
+			throw new IllegalArgumentException(e);
+		}
+		return parsed;
+	}
+
+	private static boolean containsTimeZonePattern(final String pattern) {
+		return pattern.matches("[XZz]{1,3}");	// doesn't account for strings escaped with "'" (TODO?)
+	}
+
+	private static String getPattern(final String pattern) {
+		return pattern == null ? DEFAULT_FORMAT : pattern;
+	}
+
+	private static TemporalQuery<Consumer<Map<String, Object>>> temporalQuery(final ChronoField field) {
+		return temporal -> map -> {
+			if (field.isSupportedBy(temporal)) {
+				map.put(field.getBaseUnit().toString(), field.getFrom(temporal));
+			}
+		};
+	}
+}

--- a/src/main/java/apoc/result/MapResult.java
+++ b/src/main/java/apoc/result/MapResult.java
@@ -1,5 +1,6 @@
 package apoc.result;
 
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -7,7 +8,12 @@ import java.util.Map;
  * @since 26.02.16
  */
 public class MapResult {
-    public final Map value;
+	private static final MapResult EMPTY = new MapResult(Collections.emptyMap());
+	public final Map value;
+
+	public static MapResult empty() {
+		return EMPTY;
+	}
 
     public MapResult(Map value) {
         this.value = value;

--- a/src/test/java/apoc/date/DateTest.java
+++ b/src/test/java/apoc/date/DateTest.java
@@ -1,0 +1,214 @@
+package apoc.date;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.stream.Stream;
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.graphdb.Node;
+import org.neo4j.graphdb.QueryExecutionException;
+import org.neo4j.graphdb.Transaction;
+import org.neo4j.helpers.collection.Iterators;
+import org.neo4j.test.TestGraphDatabaseFactory;
+import static apoc.util.TestUtil.testCall;
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
+import static org.junit.Assert.*;
+
+
+public class DateTest {
+	@Rule public ExpectedException expected = ExpectedException.none();
+	private GraphDatabaseService db;
+	private DateFormat defaultFormat = formatInUtcZone("yyyy-MM-dd HH:mm:ss");
+	private String epochAsString = defaultFormat.format(new java.util.Date(0L));
+
+	@Before
+	public void sUp() throws Exception {
+		db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+		TestUtil.registerProcedure(db, Date.class);
+	}
+
+	@After
+	public void tearDown() {
+		db.shutdown();
+	}
+
+	@Test public void testToUnixtime() throws Exception {
+		testCall(db,
+				"CALL apoc.date.toSeconds('" + epochAsString + "') yield value as dob RETURN dob",
+				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("dob"))));
+	}
+
+	@Test public void testToUnixtimeWithCorrectFormat() throws Exception {
+		String pattern = "HH:mm:ss/yyyy";
+		SimpleDateFormat customFormat = formatInUtcZone(pattern);
+		String reference = customFormat.format(new java.util.Date(0L));
+		testCall(db,
+				"CALL apoc.date.toSecondsFormatted('" + reference + "', '" + pattern + "') yield value as dob RETURN dob",
+				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("dob"))));
+	}
+
+	@Test public void testToUnixtimeWithIncorrectPatternFormat() throws Exception {
+		expected.expect(instanceOf(QueryExecutionException.class));
+		testCall(db,
+				"CALL apoc.date.toSecondsFormatted('12:12:12/1945', 'HH:mm:ss/yyyy/neo4j') yield value as dob RETURN dob",
+				row -> assertEquals(Instant.EPOCH, Instant.ofEpochSecond((long) row.get("dob"))));
+	}
+
+	@Test public void testToUnixtimeWithNullInput() throws Exception {
+		testCall(db,
+				"CALL apoc.date.toSeconds(NULL) yield value as dob RETURN dob",
+				row -> assertNull(row.get("dob")));
+	}
+
+	@Test public void testFromUnixtime() throws Exception {
+		testCall(db,
+				"CALL apoc.date.fromSeconds(0) yield value as dob RETURN dob",
+				row -> {
+					try {
+						assertEquals(new java.util.Date(0L), defaultFormat.parse((String) row.get("dob")));
+					} catch (ParseException e) {
+						throw new RuntimeException(e);
+					}
+				});
+	}
+
+	@Test public void testFromUnixtimeWithCorrectFormat() throws Exception {
+		String pattern = "HH:mm:ss/yyyy";
+		SimpleDateFormat customFormat = formatInUtcZone(pattern);
+		testCall(db,
+				"CALL apoc.date.fromSecondsFormatted(0, '" + pattern + "') yield value as dob RETURN dob",
+				row -> {
+					try {
+						assertEquals(new java.util.Date(0L), customFormat.parse((String) row.get("dob")));
+					} catch (ParseException e) {
+						throw new RuntimeException(e);
+					}
+				});
+	}
+
+	@Test public void testFromUnixtimeWithIncorrectPatternFormat() throws Exception {
+		expected.expect(instanceOf(QueryExecutionException.class));
+		testCall(db,
+				"CALL apoc.date.fromSecondsFormatted(0, 'HH:mm:ss/yyyy/neo4j') yield value as dob RETURN dob",
+				row -> {});
+	}
+
+	@Test public void testFromUnixtimeWithNegativeInput() throws Exception {
+		expected.expect(instanceOf(QueryExecutionException.class));
+		testCall(db, "CALL apoc.date.toSeconds(-1) yield value as dob RETURN dob", row -> {});
+	}
+
+	@Test public void testOrderByDate() throws Exception {
+		SimpleDateFormat format = formatInUtcZone("yyyy-MM-dd HH:mm:ss");
+		try (Transaction tx = db.beginTx()) {
+			for (int i = 0 ; i < 8; i++) {
+				Node datedNode = db.createNode(() -> "Person");
+				datedNode.setProperty("born", format.format(java.util.Date.from(Instant.EPOCH.plus(i, ChronoUnit.DAYS))));
+			}
+			for (int i = 15 ; i >= 8; i--) {
+				Node datedNode = db.createNode(() -> "Person");
+				datedNode.setProperty("born", format.format(java.util.Date.from(Instant.EPOCH.plus(i, ChronoUnit.DAYS))));
+			}
+			tx.success();
+		}
+
+		List<java.util.Date> expected = Stream.iterate(Instant.EPOCH, prev -> prev.plus(1, ChronoUnit.DAYS))
+				.limit(16)
+				.map(java.util.Date::from)
+				.sorted()
+				.collect(toList());
+
+		List<java.util.Date> actual;
+		try (Transaction tx = db.beginTx()) {
+			String query = "MATCH (p:Person) WITH p CALL apoc.date.toSeconds(p.born) yield value as dob RETURN p,dob ORDER BY dob ";
+			actual = Iterators.asList(db.execute(query).<Long>columnAs("dob")).stream()
+					.map(dob -> java.util.Date.from(Instant.ofEpochSecond((long) dob)))
+					.collect(toList());
+			tx.success();
+		}
+
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void testListFields() throws Exception {
+		testCall(db,
+				"CALL apoc.date.listFields('2015-01-02 03:04:05') yield value as m RETURN m",
+				row -> {
+					Map<String, Object> split = (Map<String, Object>) row.get("m");
+					assertEquals(2015L, split.get("Years"));
+					assertEquals(1L, split.get("Months"));
+					assertEquals(2L, split.get("Days"));
+					assertEquals(3L, split.get("Hours"));
+					assertEquals(4L, split.get("Minutes"));
+					assertEquals(5L, split.get("Seconds"));
+				});
+	}
+
+	@Test
+	public void testListFieldsCustomFormat() throws Exception {
+		testCall(db,
+				"CALL apoc.date.listFieldsFormatted('2015-01-02 03:04:05 EET', 'yyyy-MM-dd HH:mm:ss zzz') yield value as m RETURN m",
+				row -> {
+					Map<String, Object> split = (Map<String, Object>) row.get("m");
+					assertEquals(2015L, split.get("Years"));
+					assertEquals(1L, split.get("Months"));
+					assertEquals(2L, split.get("Days"));
+					assertEquals(3L, split.get("Hours"));
+					assertEquals(4L, split.get("Minutes"));
+					assertEquals(5L, split.get("Seconds"));
+					assertEquals("Europe/Bucharest", split.get("ZoneId"));
+				});
+
+		testCall(db,
+				"CALL apoc.date.listFieldsFormatted('2015/01/02/03/04/05/EET', 'yyyy/MM/dd/HH/mm/ss/z') yield value as m RETURN m",
+				row -> {
+					Map<String, Object> split = (Map<String, Object>) row.get("m");
+					assertEquals(2015L, split.get("Years"));
+					assertEquals(1L, split.get("Months"));
+					assertEquals(2L, split.get("Days"));
+					assertEquals(3L, split.get("Hours"));
+					assertEquals(4L, split.get("Minutes"));
+					assertEquals(5L, split.get("Seconds"));
+					assertEquals("Europe/Bucharest", split.get("ZoneId"));
+				});
+
+		testCall(db,
+				"CALL apoc.date.listFieldsFormatted('2015/01/02_EET', 'yyyy/MM/dd_z') yield value as m RETURN m",
+				row -> {
+					Map<String, Object> split = (Map<String, Object>) row.get("m");
+					assertEquals(2015L, split.get("Years"));
+					assertEquals(1L, split.get("Months"));
+					assertEquals(2L, split.get("Days"));
+					assertEquals("Europe/Bucharest", split.get("ZoneId"));
+				});
+	}
+
+	@Test
+	public void testListFieldsNullInput() throws Exception {
+		testCall(db,
+				"CALL apoc.date.listFieldsFormatted(NULL, 'yyyy-MM-dd HH:mm:ss zzz') yield value as m RETURN m",
+				row -> {
+					Map<String, Object> split = (Map<String, Object>) row.get("m");
+					assertTrue(split.isEmpty());
+				});
+	}
+
+	private SimpleDateFormat formatInUtcZone(final String pattern) {
+		SimpleDateFormat customFormat = new SimpleDateFormat(pattern);
+		customFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+		return customFormat;
+	}
+}


### PR DESCRIPTION
Inspired by a recent discussion @ slack channel, where a user was complaining that he can't compare dates stored as strings in a way other than lexicographical.
This PR adds a procedure that accepts a (string) value and an optional `DateFormat`-compatible pattern and returns a unixtime of date parsed from value with the given format. null input => null output.

Real-life example:

```
MATCH (p:Person) 
WITH p 
CALL apoc.date.unixtime(p.born) 
YIELD value AS dob
RETURN p 
ORDER BY dob
```

will order people by dates given that their 'born' field are compatible with the default `EEE MMM dd HH:mm:ss zzz yyyy` format.

Since procedure methods can't be overloaded, there's a difference in names: `unixtime(date)` vs `unixtime_f(date, format)`, which is totally disputable.