### PR TITLE
monitor apoc

### DIFF
--- a/src/main/java/apoc/monitor/Config.java
+++ b/src/main/java/apoc/monitor/Config.java
@@ -1,0 +1,42 @@
+package apoc.monitor;
+
+import apoc.Description;
+import apoc.result.ConfigInfoResult;
+import org.neo4j.graphdb.*;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Procedure;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public class Config {
+
+    private static final String PROCEDURE_NAME = "org.neo4j:instance=kernel#0,name=Configuration";
+
+    @Context
+    public GraphDatabaseService database;
+
+    @Procedure
+    @Description("apoc.monitor.config() returns the configuration parameters used to configure Neo4j")
+    public Stream<ConfigInfoResult> config() {
+        List<ConfigInfoResult> attributes = new ArrayList<>();
+        try (org.neo4j.graphdb.Transaction tx = database.beginTx()) {
+            Result result = database.execute("CALL dbms.queryJmx(\"" + PROCEDURE_NAME + "\")");
+            while (result.hasNext()) {
+                Map<String, Object> record = result.next();
+                Map<String, Object> attr = (Map<String, Object>) record.get("attributes");
+                for (String k : attr.keySet()) {
+                    Map<String, Object> v = (Map<String, Object>) attr.get(k);
+                    attributes.add(new ConfigInfoResult(k, String.valueOf(v.get("value")), String.valueOf(v.get("description"))));
+                }
+
+            }
+            tx.success();
+        }
+
+        return attributes.stream().map(p -> p);
+    }
+}

--- a/src/main/java/apoc/monitor/Id.java
+++ b/src/main/java/apoc/monitor/Id.java
@@ -7,9 +7,7 @@ import org.neo4j.jmx.JmxUtils;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
 
-import javax.management.MBeanServer;
 import javax.management.ObjectName;
-import java.util.HashMap;
 import java.util.stream.Stream;
 
 public class Id {

--- a/src/main/java/apoc/monitor/Id.java
+++ b/src/main/java/apoc/monitor/Id.java
@@ -1,0 +1,47 @@
+package apoc.monitor;
+
+import apoc.Description;
+import apoc.result.IdsResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.jmx.JmxUtils;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Procedure;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.util.HashMap;
+import java.util.stream.Stream;
+
+public class Id {
+
+    private static final String JMX_OBJECT_NAME = "Primitive count";
+    private static final String NODE_IDS_KEY = "NumberOfNodeIdsInUse";
+    private static final String REL_IDS_KEY = "NumberOfRelationshipIdsInUse";
+    private static final String PROP_IDS_KEY = "NumberOfPropertyIdsInUse";
+    private static final String REL_TYPE_IDS_KEY = "NumberOfRelationshipTypeIdsInUse";
+
+    @Context
+    public GraphDatabaseService database;
+
+    @Procedure
+    @Description("apoc.monitor.ids() returns the object ids in use for this neo4j instance")
+    public Stream<IdsResult> ids() throws Exception {
+        return Stream.of(getIdsInUse());
+    }
+
+    private IdsResult getIdsInUse() {
+        ObjectName objectName = JmxUtils.getObjectName(database, JMX_OBJECT_NAME);
+
+        return new IdsResult(
+                getAttribute(objectName, NODE_IDS_KEY),
+                getAttribute(objectName, REL_IDS_KEY),
+                getAttribute(objectName, PROP_IDS_KEY),
+                getAttribute(objectName, REL_TYPE_IDS_KEY)
+        );
+    }
+
+    private long getAttribute(ObjectName objectName, String attribute) {
+        return JmxUtils.getAttribute(objectName, attribute);
+    }
+
+}

--- a/src/main/java/apoc/monitor/Id.java
+++ b/src/main/java/apoc/monitor/Id.java
@@ -22,7 +22,7 @@ public class Id extends Monitor {
 
     @Procedure
     @Description("apoc.monitor.ids() returns the object ids in use for this neo4j instance")
-    public Stream<IdsResult> ids() throws Exception {
+    public Stream<IdsResult> ids() {
         return Stream.of(getIdsInUse());
     }
 

--- a/src/main/java/apoc/monitor/Id.java
+++ b/src/main/java/apoc/monitor/Id.java
@@ -3,14 +3,13 @@ package apoc.monitor;
 import apoc.Description;
 import apoc.result.IdsResult;
 import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.jmx.JmxUtils;
 import org.neo4j.procedure.Context;
 import org.neo4j.procedure.Procedure;
 
 import javax.management.ObjectName;
 import java.util.stream.Stream;
 
-public class Id {
+public class Id extends Monitor {
 
     private static final String JMX_OBJECT_NAME = "Primitive count";
     private static final String NODE_IDS_KEY = "NumberOfNodeIdsInUse";
@@ -28,18 +27,13 @@ public class Id {
     }
 
     private IdsResult getIdsInUse() {
-        ObjectName objectName = JmxUtils.getObjectName(database, JMX_OBJECT_NAME);
+        ObjectName objectName = getObjectName(database, JMX_OBJECT_NAME);
 
         return new IdsResult(
-                getAttribute(objectName, NODE_IDS_KEY),
-                getAttribute(objectName, REL_IDS_KEY),
-                getAttribute(objectName, PROP_IDS_KEY),
-                getAttribute(objectName, REL_TYPE_IDS_KEY)
+                (long) getAttribute(objectName, NODE_IDS_KEY),
+                (long) getAttribute(objectName, REL_IDS_KEY),
+                (long) getAttribute(objectName, PROP_IDS_KEY),
+                (long) getAttribute(objectName, REL_TYPE_IDS_KEY)
         );
     }
-
-    private long getAttribute(ObjectName objectName, String attribute) {
-        return JmxUtils.getAttribute(objectName, attribute);
-    }
-
 }

--- a/src/main/java/apoc/monitor/KernelInfo.java
+++ b/src/main/java/apoc/monitor/KernelInfo.java
@@ -1,0 +1,49 @@
+package apoc.monitor;
+
+import apoc.Description;
+import apoc.result.KernelInfoResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Procedure;
+
+import javax.management.ObjectName;
+import java.util.Date;
+import java.util.stream.Stream;
+
+public class KernelInfo extends Monitor {
+
+    private static final String JMX_OBJECT_NAME = "Kernel";
+    private static final String READ_ONLY = "ReadOnly";
+    private static final String KERNEL_VERSION = "KernelVersion";
+    private static final String STORE_ID = "StoreId";
+    private static final String START_TIME = "KernelStartTime";
+    private static final String DB_NAME = "DatabaseName";
+    private static final String STORE_LOG_VERSION = "StoreLogVersion";
+    private static final String STORE_CREATION_DATE = "StoreCreationDate";
+
+
+    @Context
+    public GraphDatabaseService database;
+
+    @Procedure
+    @Description("apoc.monitor.kernelInfo() returns informations about the neo4j kernel")
+    public Stream<KernelInfoResult> kernelInfo() {
+        Date time = (Date) getAttribute(getObjectName(database, JMX_OBJECT_NAME), START_TIME);
+        return Stream.of(getKernelInfo());
+    }
+
+    private KernelInfoResult getKernelInfo() {
+        ObjectName objectName = getObjectName(database, JMX_OBJECT_NAME);
+
+        return new KernelInfoResult(
+                (Boolean) getAttribute(objectName, READ_ONLY),
+                String.valueOf(getAttribute(objectName, KERNEL_VERSION)),
+                String.valueOf(getAttribute(objectName, STORE_ID)),
+                ((Date) getAttribute(objectName, START_TIME)).getTime(),
+                String.valueOf(getAttribute(objectName, DB_NAME)),
+                (long) getAttribute(objectName, STORE_LOG_VERSION),
+                ((Date) getAttribute(objectName, STORE_CREATION_DATE)).getTime()
+        );
+    }
+
+}

--- a/src/main/java/apoc/monitor/Monitor.java
+++ b/src/main/java/apoc/monitor/Monitor.java
@@ -1,0 +1,18 @@
+package apoc.monitor;
+
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.jmx.JmxUtils;
+
+import javax.management.ObjectName;
+
+public class Monitor {
+
+    protected ObjectName getObjectName(GraphDatabaseService db, String name) {
+        return JmxUtils.getObjectName(db, name);
+    }
+
+    protected Object getAttribute(ObjectName objectName, String attribute) {
+        return JmxUtils.getAttribute(objectName, attribute);
+    }
+
+}

--- a/src/main/java/apoc/monitor/Store.java
+++ b/src/main/java/apoc/monitor/Store.java
@@ -1,0 +1,47 @@
+package apoc.monitor;
+
+import apoc.Description;
+import apoc.result.StoreInfoResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Procedure;
+
+import javax.management.ObjectName;
+import java.util.stream.Stream;
+
+public class Store extends Monitor {
+
+    private static final String JMX_OBJECT_NAME = "Store file sizes";
+    private static final String LOG_SIZE = "LogicalLogSize";
+    private static final String STRING_SIZE = "StringStoreSize";
+    private static final String ARRAY_SIZE = "ArrayStoreSize";
+    private static final String REL_SIZE = "RelationshipStoreSize";
+    private static final String PROP_SIZE = "PropertyStoreSize";
+    private static final String TOTAL_SIZE = "TotalStoreSize";
+    private static final String NODE_SIZE = "NodeStoreSize";
+
+    @Context
+    public GraphDatabaseService database;
+
+    @Procedure
+    @Description("apoc.monitor.store() returns informations about the sizes of the different parts of the neo4j graph store")
+    public Stream<StoreInfoResult> store() {
+        return Stream.of(getStoreInfo());
+    }
+
+    private StoreInfoResult getStoreInfo() {
+        ObjectName objectName = getObjectName(database, JMX_OBJECT_NAME);
+
+        return new StoreInfoResult(
+                (long) getAttribute(objectName, LOG_SIZE),
+                (long) getAttribute(objectName, STRING_SIZE),
+                (long) getAttribute(objectName, ARRAY_SIZE),
+                (long) getAttribute(objectName, REL_SIZE),
+                (long) getAttribute(objectName, PROP_SIZE),
+                (long) getAttribute(objectName, TOTAL_SIZE),
+                (long) getAttribute(objectName, NODE_SIZE)
+        );
+    }
+
+
+}

--- a/src/main/java/apoc/monitor/Transaction.java
+++ b/src/main/java/apoc/monitor/Transaction.java
@@ -1,0 +1,46 @@
+package apoc.monitor;
+
+import apoc.Description;
+import apoc.result.TransactionInfoResult;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.procedure.Context;
+import org.neo4j.procedure.Procedure;
+
+import javax.management.ObjectName;
+import java.util.stream.Stream;
+
+public class Transaction extends Monitor {
+
+    private static final String JMX_OBJECT_NAME = "Transactions";
+    private static final String ROLLED_BACK_TX = "NumberOfRolledBackTransactions";
+    private static final String PEAK_TX = "PeakNumberOfConcurrentTransactions";
+    private static final String LAST_TX_ID = "LastCommittedTxId";
+    private static final String OPEN_TX = "NumberOfOpenTransactions";
+    private static final String OPENED_TX = "NumberOfOpenedTransactions";
+    private static final String COMMITTED_TX = "NumberOfCommittedTransactions";
+
+    @Context
+    public GraphDatabaseService database;
+
+    @Procedure
+    @Description("apoc.monitor.tx() returns informations about the neo4j transaction manager")
+    public Stream<TransactionInfoResult> tx() throws Exception {
+        return Stream.of(getTransactionInfo());
+    }
+
+    private TransactionInfoResult getTransactionInfo() throws Exception {
+        ObjectName objectName = getObjectName(database, JMX_OBJECT_NAME);
+
+        return new TransactionInfoResult(
+                (long) getAttribute(objectName, ROLLED_BACK_TX),
+                (long) getAttribute(objectName, PEAK_TX),
+                (long) getAttribute(objectName, LAST_TX_ID),
+                (long) getAttribute(objectName, OPEN_TX),
+                (long) getAttribute(objectName, OPENED_TX),
+                (long) getAttribute(objectName, COMMITTED_TX)
+        );
+    }
+
+
+
+}

--- a/src/main/java/apoc/result/ConfigInfoResult.java
+++ b/src/main/java/apoc/result/ConfigInfoResult.java
@@ -1,0 +1,17 @@
+package apoc.result;
+
+public class ConfigInfoResult {
+
+    public String name;
+
+    public String value;
+
+    public String description;
+
+    public ConfigInfoResult(String name, String value, String description) {
+        this.name = name;
+        this.value = value;
+        this.description = description;
+    }
+
+}

--- a/src/main/java/apoc/result/IdsResult.java
+++ b/src/main/java/apoc/result/IdsResult.java
@@ -1,0 +1,22 @@
+package apoc.result;
+
+import java.util.Map;
+
+public class IdsResult {
+
+    public long nodeIds;
+
+    public long relIds;
+
+    public long propIds;
+
+    public long relTypeIds;
+
+    public IdsResult(long nodeIds, long relIds, long propIds, long relTypeIds) {
+        this.nodeIds = nodeIds;
+        this.relIds = relIds;
+        this.propIds = propIds;
+        this.relTypeIds = relTypeIds;
+    }
+
+}

--- a/src/main/java/apoc/result/KernelInfoResult.java
+++ b/src/main/java/apoc/result/KernelInfoResult.java
@@ -1,0 +1,39 @@
+package apoc.result;
+
+import apoc.monitor.KernelInfo;
+
+public class KernelInfoResult {
+
+    public Boolean readOnly;
+
+    public String kernelVersion;
+
+    public String storeId;
+
+    public long kernelStartTime;
+
+    public String databaseName;
+
+    public long storeLogVersion;
+
+    public long storeCreationDate;
+
+    public KernelInfoResult(
+            Boolean readOnly,
+            String kernelVersion,
+            String storeId,
+            long kernelStartTime,
+            String databaseName,
+            long storeLogVersion,
+            long storeCreationDate
+            ) {
+        this.readOnly = readOnly;
+        this.kernelVersion = kernelVersion;
+        this.storeId = storeId;
+        this.kernelStartTime = kernelStartTime;
+        this.databaseName = databaseName;
+        this.storeLogVersion = storeLogVersion;
+        this.storeCreationDate = storeCreationDate;
+    }
+
+}

--- a/src/main/java/apoc/result/StoreInfoResult.java
+++ b/src/main/java/apoc/result/StoreInfoResult.java
@@ -1,0 +1,37 @@
+package apoc.result;
+
+public class StoreInfoResult {
+
+    public long logSize;
+
+    public long stringStoreSize;
+
+    public long arrayStoreSize;
+
+    public long relStoreSize;
+
+    public long propStoreSize;
+
+    public long totalStoreSize;
+
+    public long nodeStoreSize;
+
+    public StoreInfoResult(
+            long logSize,
+            long stringStoreSize,
+            long arrayStoreSize,
+            long relStoreSize,
+            long propStoreSize,
+            long totalStoreSize,
+            long nodeStoreSize
+    ) {
+        this.logSize = logSize;
+        this.stringStoreSize = stringStoreSize;
+        this.arrayStoreSize = arrayStoreSize;
+        this.relStoreSize = relStoreSize;
+        this.propStoreSize = propStoreSize;
+        this.totalStoreSize = totalStoreSize;
+        this.nodeStoreSize = nodeStoreSize;
+    }
+
+}

--- a/src/main/java/apoc/result/TransactionInfoResult.java
+++ b/src/main/java/apoc/result/TransactionInfoResult.java
@@ -1,0 +1,33 @@
+package apoc.result;
+
+public class TransactionInfoResult {
+
+    public long rolledBackTx;
+
+    public long peakTx;
+
+    public long lastTxId;
+
+    public long currentOpenedTx;
+
+    public long totalOpenedTx;
+
+    public long totalTx;
+
+    public TransactionInfoResult(
+            long rolledBackTx,
+            long peakTx,
+            long lastTxId,
+            long currentOpenedTx,
+            long totalOpenedTx,
+            long totalTx
+    ) {
+        this.rolledBackTx = rolledBackTx;
+        this.peakTx = peakTx;
+        this.lastTxId = lastTxId;
+        this.currentOpenedTx = currentOpenedTx;
+        this.totalOpenedTx = totalOpenedTx;
+        this.totalTx = totalTx;
+    }
+
+}

--- a/src/test/java/apoc/monitor/IdProcedureTest.java
+++ b/src/test/java/apoc/monitor/IdProcedureTest.java
@@ -1,5 +1,6 @@
 package apoc.monitor;
 
+import apoc.util.TestUtil;
 import org.junit.Test;
 
 import static org.junit.Assert.*;

--- a/src/test/java/apoc/monitor/IdProcedureTest.java
+++ b/src/test/java/apoc/monitor/IdProcedureTest.java
@@ -1,11 +1,6 @@
 package apoc.monitor;
 
-import apoc.util.TestUtil;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.neo4j.graphdb.GraphDatabaseService;
-import org.neo4j.test.TestGraphDatabaseFactory;
 
 import static org.junit.Assert.*;
 

--- a/src/test/java/apoc/monitor/IdProcedureTest.java
+++ b/src/test/java/apoc/monitor/IdProcedureTest.java
@@ -11,14 +11,11 @@ import static org.junit.Assert.*;
 
 import static apoc.util.TestUtil.testCall;
 
-public class IdProcedureTest {
+public class IdProcedureTest extends MonitorTestCase {
 
-    private static GraphDatabaseService db;
-
-    @Before
-    public void setUp() throws Exception {
-        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
-        TestUtil.registerProcedure(db, Id.class);
+    @Override
+    Class procedureClass() {
+        return Id.class;
     }
 
     @Test
@@ -41,11 +38,6 @@ public class IdProcedureTest {
         testCall(db, "CREATE (n)-[:REL_TYPE1]->(n2)", (row) -> {});
         testCall(db, "CREATE (n)-[:REL_TYPE2]->(n2)", (row) -> {});
         testCall(db, "CREATE (n) SET n.key = 123", (row) -> {});
-    }
-
-    @After
-    public void tearDown() {
-        db.shutdown();
     }
 
 }

--- a/src/test/java/apoc/monitor/IdProcedureTest.java
+++ b/src/test/java/apoc/monitor/IdProcedureTest.java
@@ -1,0 +1,51 @@
+package apoc.monitor;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+import static org.junit.Assert.*;
+
+import static apoc.util.TestUtil.testCall;
+
+public class IdProcedureTest {
+
+    private static GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        TestUtil.registerProcedure(db, Id.class);
+    }
+
+    @Test
+    public void testGetNodeIdsInUse() {
+        createData();
+        testCall(db, "CALL apoc.monitor.ids()", (row) -> {
+            long nodeIds = (long) row.get("nodeIds");
+            long relIds = (long) row.get("relIds");
+            long propIds = (long) row.get("propIds");
+            long relTypeIds = (long) row.get("relTypeIds");
+            assertEquals(6L, nodeIds);
+            assertEquals(2L, relIds);
+            assertEquals(1L, propIds);
+            assertEquals(2L, relTypeIds);
+        });
+    }
+
+    private void createData() {
+        testCall(db, "CREATE (n)", (row) -> {});
+        testCall(db, "CREATE (n)-[:REL_TYPE1]->(n2)", (row) -> {});
+        testCall(db, "CREATE (n)-[:REL_TYPE2]->(n2)", (row) -> {});
+        testCall(db, "CREATE (n) SET n.key = 123", (row) -> {});
+    }
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+}

--- a/src/test/java/apoc/monitor/KernelInfoProcedureTest.java
+++ b/src/test/java/apoc/monitor/KernelInfoProcedureTest.java
@@ -1,0 +1,27 @@
+package apoc.monitor;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static apoc.util.TestUtil.testCall;
+
+public class KernelInfoProcedureTest extends MonitorTestCase {
+
+    @Override
+    Class procedureClass() {
+        return KernelInfo.class;
+    }
+
+    @Test
+    public void testGetKernelInfo() {
+        long now = System.currentTimeMillis();
+        testCall(db, "CALL apoc.monitor.kernelInfo()", (row) -> {
+            long startTime = (long) row.get("kernelStartTime");
+            String kernelVersion = String.valueOf(row.get("kernelVersion"));
+            assertEquals("impermanent-db", String.valueOf(row.get("databaseName")));
+            assertTrue(startTime < now);
+            assertTrue(kernelVersion.contains("3.0.0"));
+            assertEquals(0, (long) row.get("storeLogVersion"));
+        });
+    }
+}

--- a/src/test/java/apoc/monitor/MonitorTestCase.java
+++ b/src/test/java/apoc/monitor/MonitorTestCase.java
@@ -1,0 +1,31 @@
+package apoc.monitor;
+
+import apoc.util.TestUtil;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.neo4j.graphdb.GraphDatabaseService;
+import org.neo4j.test.TestGraphDatabaseFactory;
+
+public abstract class MonitorTestCase {
+
+    protected static GraphDatabaseService db;
+
+    @Before
+    public void setUp() throws Exception {
+        db = new TestGraphDatabaseFactory().newImpermanentDatabase();
+        registerProcedure();
+    }
+
+    abstract Class procedureClass();
+
+    @After
+    public void tearDown() {
+        db.shutdown();
+    }
+
+    private void registerProcedure() throws Exception {
+        TestUtil.registerProcedure(db, procedureClass());
+    }
+
+}

--- a/src/test/java/apoc/monitor/StoreInfoProcedureTest.java
+++ b/src/test/java/apoc/monitor/StoreInfoProcedureTest.java
@@ -1,0 +1,27 @@
+package apoc.monitor;
+
+import org.junit.Test;
+
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.*;
+
+public class StoreInfoProcedureTest extends MonitorTestCase {
+
+    @Override
+    Class procedureClass() {
+        return Store.class;
+    }
+
+    @Test
+    public void testGetStoreInfo() {
+        testCall(db, "CALL apoc.monitor.store()", (row) -> {
+            assertNotNull(row.get("logSize"));
+            assertNotNull(row.get("stringStoreSize"));
+            assertNotNull(row.get("arrayStoreSize"));
+            assertNotNull(row.get("nodeStoreSize"));
+            assertNotNull(row.get("relStoreSize"));
+            assertNotNull(row.get("propStoreSize"));
+            assertNotNull(row.get("totalStoreSize"));
+        });
+    }
+}

--- a/src/test/java/apoc/monitor/TransactionProcedureTest.java
+++ b/src/test/java/apoc/monitor/TransactionProcedureTest.java
@@ -1,0 +1,36 @@
+package apoc.monitor;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import javax.management.ObjectName;
+
+import static apoc.util.TestUtil.testCall;
+import static org.junit.Assert.*;
+
+@Ignore
+public class TransactionProcedureTest extends MonitorTestCase {
+
+    @Override
+    Class procedureClass() {
+        return Transaction.class;
+    }
+
+    // These tests fails with an impermanent db
+
+//
+//    @Test
+//    public void testGetTransactionInfo() {
+//        createData();
+//        ObjectName objectName = JmxUtils.getObjectName(db, "Transactions");
+//        long tx = (long) JmxUtils.getAttribute(objectName, "NumberOfRolledBackTransactions");
+//        System.out.println(tx);
+//        testCall(db, "CALL apoc.monitor.tx()", (row) -> {
+//            assertEquals(0, (long) row.get("rolledBackTx"));
+//        });
+//    }
+//
+//    private void createData() {
+//        testCall(db, "CREATE (n)", (row) -> {});
+//    }
+}


### PR DESCRIPTION
Do not merge, work in progress.

* `apoc.monitor.ids()` : return graph object ids in use
* `apoc.monitor.kernelInfo()` : return infos about the neo4j instance
* `apoc.monitor.tx()` : return infos about the neo4j transaction manager
* `apoc.monitor.store()` : return infos about the sizes of the different parts of the Neo4j graph store
* `apoc.monitor.config()` : return the neo4j configuration settings

Notes :

* Cannot inject the JmxServer, so getting the description with MBeanInfo is not possible, please check if there is a workaround 